### PR TITLE
Patch/to elixir 1.0

### DIFF
--- a/lib/sphero.ex
+++ b/lib/sphero.ex
@@ -1,5 +1,5 @@
 defmodule Sphero do
-  use Application.Behaviour
+  use Application
 
   # See http://elixir-lang.org/docs/stable/Application.Behaviour.html
   # for more information on OTP Applications

--- a/lib/sphero/client.ex
+++ b/lib/sphero/client.ex
@@ -23,7 +23,7 @@ defmodule Sphero.Client do
   end
 
   definit device do
-    device = :serial.start([speed: 115200, open: bitstring_to_list(device)])
+    device = :serial.start([speed: 115200, open: :erlang.bitstring_to_list(device)])
     initial_state(%State{device: device, seq: 0})
   end
 

--- a/lib/sphero/command.ex
+++ b/lib/sphero/command.ex
@@ -6,14 +6,14 @@ end
 
 defmodule Sphero.Command.Roll do
   def new([seq: seq, speed: speed, heading: heading, delay: delay]) do
-    data = <<speed, heading :: [unsigned, size(16)], delay>>
+    data = <<speed, heading :: unsigned-size(16), delay>>
     Sphero.Command.new(seq: seq, data: data, cid: <<48>>)
   end
 end
 
 defmodule Sphero.Command.Heading do
   def new([seq: seq, heading: heading]) do
-    data = <<heading :: [unsigned, size(16)]>>
+    data = <<heading :: unsigned-size(16)>>
     Sphero.Command.new(seq: seq, data: data, cid: <<1>>)
   end
 end
@@ -44,7 +44,7 @@ end
 
 defmodule Sphero.Command.SetDataStreaming do
   def new([seq: seq, n: n, m: m, mask: mask, pcnt: pcnt, mask2: mask2]) do
-    data = <<n :: [unsigned, size(16)], m :: [unsigned, size(16)], mask :: [unsigned, size(32)], pcnt, mask2 :: [unsigned, size(32)]>>
+    data = <<n :: unsigned-size(16), m :: unsigned-size(16), mask :: unsigned-size(32), pcnt, mask2 :: unsigned-size(32)>>
     Sphero.Command.new(seq: seq, data: data, cid: <<18>>)
   end
 end

--- a/lib/sphero/request.ex
+++ b/lib/sphero/request.ex
@@ -72,6 +72,6 @@ end
 defmodule Sphero.Request.Sleep do
   def new([seq: seq, wakeup: wakeup, macro: macro]) do
     # Convert wakeup to an unsigned 16-bit packed integer
-    %Sphero.Request{seq: seq, data: <<macro, wakeup :: [unsigned, size(16)]>>, cid: <<34>>}
+    %Sphero.Request{seq: seq, data: <<macro, wakeup :: unsigned-size(16)>>, cid: <<34>>}
   end
 end

--- a/lib/sphero/supervisor.ex
+++ b/lib/sphero/supervisor.ex
@@ -1,5 +1,5 @@
 defmodule Sphero.Supervisor do
-  use Supervisor.Behaviour
+  use Supervisor
 
   def start_link do
     :supervisor.start_link(__MODULE__, [])

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,8 @@ defmodule Sphero.Mixfile do
   defp deps do
     [
       {:exactor, github: "sasa1977/exactor"},
-      {:"erlang-serial", github: "knewter/erlang-serial"}
+      {:"erlang-serial", github: "knewter/erlang-serial", app: false}
     ]
   end
 end
+


### PR DESCRIPTION
- Update mix.exs to fix compile error
- Update to use erlang.bitstring_to_list deprecated in 0.13
- Update to new syntax for bitstrings courtesy of Jose Valim suggestion here https://groups.google.com/forum/#!topic/elixir-lang-talk/AjEYNYc2-8M
